### PR TITLE
Add support for specifying the i2c-bus by providing the device-name.

### DIFF
--- a/src/ecc508.erl
+++ b/src/ecc508.erl
@@ -3,7 +3,7 @@
 -include_lib("public_key/include/public_key.hrl").
 
 %% API exports
--export([start_link/0, stop/1,
+-export([start_link/0, start_link/1, stop/1,
          wake/1, idle/1, sleep/1, reset/1,
          serial_num/1,
          lock/2, lock/3,
@@ -54,10 +54,17 @@
                   data = <<>> :: binary()
                  }).
 
-%% @doc Start and link the ecc process with a the default i2c bus,
+%% @doc Start and link the ecc process with the default i2c bus,
 %% address and default max count.
+- spec start_link() -> {ok, pid()} | {error, term()}.
 start_link() ->
-    i2c:start_link("i2c-1", 16#60, ?CMDGRP_COUNT_MAX).
+    start_link("i2c-1").
+
+%% @doc Start and link the ecc process with a given devname i2c bus, the
+%% default address and the default max count.
+- spec start_link(string()) -> {ok, pid()} | {error, term()}.
+start_link(DevName) ->
+    i2c:start_link(DevName, 16#60, ?CMDGRP_COUNT_MAX).
 
 %% @doc Stops the given ecc process.
 stop(Pid) ->


### PR DESCRIPTION
Hi,

We're running the ecc-chip on another bus. Maintaining our own dependencies is not really preferable so I hope this is acceptable. 

My intent is to make this configurable in the manufacturing-tool and the miner. 

Did basic testing from shell. 
